### PR TITLE
Rooted vehicle movement (#13342 for example)

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16917,6 +16917,11 @@ void Unit::_EnterVehicle(Vehicle* vehicle, int8 seatId, AuraApplication const* a
         }
     }
 
+    // Check if there is unit type non move on vehicle
+    // If so, root the vehicle once someone gets in
+    if (vehicle->GetBase()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE))
+        SetControlled(true, UNIT_STATE_ROOT);
+
     ASSERT(!m_vehicle);
     (void)vehicle->AddPassenger(this, seatId);
 }

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -196,6 +196,10 @@ void Vehicle::ApplyAllImmunities()
         _me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, true);
     }
 
+    // Honour non movement flag (4)
+    if (_me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE))
+        _me->SetControlled(true, UNIT_STATE_ROOT);
+
     // Different immunities for vehicles goes below
     switch (GetVehicleInfo()->m_ID)
     {


### PR DESCRIPTION
Corrects issue where certain combinations of actions would cause vehicles (usually cannons/artillary) that should be rooted, to be fully movable

Update 30/11/14:
- Changed to only check live flags

Update 02/01/15:
- Changed to only check flags on vehicle entry
- Packet check only for certain movement flag combinations
- Corrected PITCH checks
