### PR TITLE
Pooling update - Interim commit.

### DIFF
--- a/README-pooling
+++ b/README-pooling
@@ -1,0 +1,27 @@
+The aim of this branch is to update the pooling system as follows:
+
+ - Create a possibility to specify a minimum number of spawned objects
+ - Ensure the maximum value are actually spawned
+ - Ensure that the minumum number are maintained in the world
+
+Completion: 40%
+
+ - Databases and Pool functionality updated to handle minimum value in template: 100%
+ - Added pool information to npc info (creature pool): 100%
+ - Spawn insurance of 100% max spawn if possible: 80% (this seems to work, but I have seen npc info report not all spawned. So need to check)
+
+Creature specific:
+ - When creatures in pool drop below minimum, then process is as follows: (100% but needs testing)
+   - looks for a dead despawned creature in the pool, if found - instant respawn
+   - if none despawned, looks for a looted corpse. If found, despawns corpse
+   - if no looted corpses found, then finds an unlooted corpse and despawns it
+   - Creature class upon creature despawn, will check if an expedited respawn is required. If so, will respawn right away.
+
+ Resource Node (maybe all game objects in pools) specific:
+ - When nodes in pool drop below minimum, then process to be determined to maintain minimum nodes in pool (0%)
+
+ To Do:
+
+ - Currently more is exposed in PoolManager class than needs to be (this is due to extra detail being shows in npc info for debug purposes during development)
+ - I'm not too happy about making the ExplicitlyChanced and EqualChanced lists directly available from PoolGroup. But, it was the fastest way to achieve this.
+   It doesn't seem to pose a terrible problem.

--- a/sql/updates/world/2014_11_25_99_world.sql
+++ b/sql/updates/world/2014_11_25_99_world.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pool_template ADD COLUMN min_limit int(10) unsigned NOT NULL DEFAULT 0 AFTER entry;
+DELETE FROM trinity_string WHERE entry=20078;
+INSERT INTO trinity_string VALUES (20078, 'Pool ID: %u. Template: Minimum: %u, Maximum: %u. Current alive in pool: %u', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -252,6 +252,11 @@ void Creature::RemoveCorpse(bool setSpawnTime)
     GetRespawnPosition(x, y, z, &o);
     SetHomePosition(x, y, z, o);
     GetMap()->CreatureRelocation(this, x, y, z, o);
+
+    // If corpse was just removed, and the creature pool is below minimum
+    // Make a respawn now
+    if (sPoolMgr->NeedExpeditedRespawn(GetGUIDLow()))
+        Respawn();
 }
 
 /**
@@ -1478,6 +1483,11 @@ void Creature::setDeathState(DeathState s)
 
         if ((CanFly() || IsFlying()))
             GetMotionMaster()->MoveFall();
+
+        // Pool function to handle creature death
+        // Mainly checks if there is a need to expedite a despawn/respawn
+        // when pool drops below minumum threshold
+        sPoolMgr->HandleCreatureDeath(GetGUIDLow());
 
         Unit::setDeathState(CORPSE);
     }

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1200,6 +1200,7 @@ enum TrinityStrings
     LANG_BAN_ACCOUNT_YOUPERMBANNEDMESSAGE_WORLD   = 11007,
 
     LANG_NPCINFO_INHABIT_TYPE                     = 11008,
-    LANG_NPCINFO_FLAGS_EXTRA                      = 11009
+    LANG_NPCINFO_FLAGS_EXTRA                      = 11009,
+    LANG_NPCINFO_POOLINFO                         = 20078
 };
 #endif

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -21,6 +21,7 @@
 #include "ObjectMgr.h"
 #include "Log.h"
 #include "MapManager.h"
+#include "Unit.h"
 
 ////////////////////////////////////////////////////////////
 // template class ActivePoolData
@@ -129,7 +130,7 @@ void ActivePoolData::RemoveObject<Quest>(uint32 quest_id, uint32 pool_id)
 
 // Method to add a gameobject/creature guid to the proper list depending on pool type and chance value
 template <class T>
-void PoolGroup<T>::AddEntry(PoolObject& poolitem, uint32 maxentries)
+void PoolGroup<T>::AddEntry(PoolObject& poolitem, uint32 minentries, uint32 maxentries)
 {
     if (poolitem.chance != 0 && maxentries == 1)
         ExplicitlyChanced.push_back(poolitem);
@@ -220,6 +221,7 @@ void PoolGroup<Creature>::Despawn1Object(uint32 guid)
     if (CreatureData const* data = sObjectMgr->GetCreatureData(guid))
     {
         sObjectMgr->RemoveCreatureFromGrid(guid, data);
+        TC_LOG_DEBUG("pool", "Despawning creature %u", guid);
 
         if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, guid), (Creature*)NULL))
             creature->AddObjectToRemoveList();
@@ -312,10 +314,11 @@ void PoolGroup<Pool>::RemoveOneRelation(uint32 child_pool_id)
 }
 
 template <class T>
-void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom)
+void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 minlimit, uint32 maxlimit, uint32 triggerFrom)
 {
     uint32 lastDespawned = 0;
-    int count = limit - spawns.GetActiveObjectCount(poolId);
+    int count = maxlimit - spawns.GetActiveObjectCount(poolId);
+    TC_LOG_DEBUG("pool", "Spawning pool %u. Already active %u max: %u available %lu trying for %u", poolId, spawns.GetActiveObjectCount(poolId), maxlimit, EqualChanced.size() + ExplicitlyChanced.size(), count);
 
     // If triggered from some object respawn this object is still marked as spawned
     // and also counted into m_SpawnedPoolAmount so we need increase count to be
@@ -349,6 +352,10 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
             triggerFrom = 0;
         }
     }
+
+    // If full population wasn't spawned and there are enough spawn points to do so. Go again!
+    if (spawns.GetActiveObjectCount(poolId) < std::min(maxlimit,uint32(EqualChanced.size()) + uint32(ExplicitlyChanced.size())))
+        SpawnObject(spawns, minlimit, std::min(maxlimit,uint32(EqualChanced.size()) + uint32(ExplicitlyChanced.size())), triggerFrom);
 }
 
 // Method that is actualy doing the spawn job on 1 creature
@@ -366,6 +373,7 @@ void PoolGroup<Creature>::Spawn1Object(PoolObject* obj)
         {
             Creature* creature = new Creature();
             //TC_LOG_DEBUG("pool", "Spawning creature %u", guid);
+            TC_LOG_DEBUG("pool", "Spawning creature %u", obj->guid);
             if (!creature->LoadCreatureFromDB(obj->guid, map))
             {
                 delete creature;
@@ -435,7 +443,7 @@ void PoolGroup<Quest>::Spawn1Object(PoolObject* obj)
 }
 
 template <>
-void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom)
+void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 minlimit, uint32 maxlimit, uint32 triggerFrom)
 {
     TC_LOG_DEBUG("pool", "PoolGroup<Quest>: Spawning pool %u", poolId);
     // load state from db
@@ -455,8 +463,8 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
                 spawns.ActivateObject<Quest>(questId, poolId);
                 PoolObject tempObj(questId, 0.0f);
                 Spawn1Object(&tempObj);
-                --limit;
-            } while (result->NextRow() && limit);
+                --maxlimit;
+            } while (result->NextRow() && maxlimit);
             return;
         }
     }
@@ -476,14 +484,14 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
     DespawnObject(spawns);
 
     // recycle minimal amount of quests if possible count is lower than limit
-    if (limit > newQuests.size() && !currentQuests.empty())
+    if (maxlimit > newQuests.size() && !currentQuests.empty())
     {
         do
         {
             uint32 questId = Trinity::Containers::SelectRandomContainerElement(currentQuests);
             newQuests.insert(questId);
             currentQuests.erase(questId);
-        } while (newQuests.size() < limit && !currentQuests.empty()); // failsafe
+        } while (newQuests.size() < maxlimit && !currentQuests.empty()); // failsafe
     }
 
     if (newQuests.empty())
@@ -497,8 +505,8 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
         PoolObject tempObj(questId, 0.0f);
         Spawn1Object(&tempObj);
         newQuests.erase(questId);
-        --limit;
-    } while (limit && !newQuests.empty());
+        --maxlimit;
+    } while (maxlimit && !newQuests.empty());
 
     // if we are here it means the pool is initialized at startup and did not have previous saved state
     if (!triggerFrom)
@@ -511,7 +519,10 @@ void PoolGroup<Creature>::ReSpawn1Object(PoolObject* obj)
 {
     if (CreatureData const* data = sObjectMgr->GetCreatureData(obj->guid))
         if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, obj->guid), (Creature*)NULL))
+        {
             creature->GetMap()->AddToMap(creature);
+            TC_LOG_DEBUG("pool", "Respawning creature %u", obj->guid);
+        }
 }
 
 // Method that does the respawn job on the specified gameobject
@@ -562,7 +573,7 @@ void PoolMgr::LoadFromDB()
     {
         uint32 oldMSTime = getMSTime();
 
-        QueryResult result = WorldDatabase.Query("SELECT entry, max_limit FROM pool_template");
+        QueryResult result = WorldDatabase.Query("SELECT entry, min_limit, max_limit FROM pool_template");
         if (!result)
         {
             mPoolTemplate.clear();
@@ -578,7 +589,8 @@ void PoolMgr::LoadFromDB()
             uint32 pool_id = fields[0].GetUInt32();
 
             PoolTemplateData& pPoolTemplate = mPoolTemplate[pool_id];
-            pPoolTemplate.MaxLimit  = fields[1].GetUInt32();
+            pPoolTemplate.MinLimit  = fields[1].GetUInt32();
+            pPoolTemplate.MaxLimit  = fields[2].GetUInt32();
 
             ++count;
         }
@@ -631,7 +643,7 @@ void PoolMgr::LoadFromDB()
                 PoolObject plObject = PoolObject(guid, chance);
                 PoolGroup<Creature>& cregroup = mPoolCreatureGroups[pool_id];
                 cregroup.SetPoolId(pool_id);
-                cregroup.AddEntry(plObject, pPoolTemplate->MaxLimit);
+                cregroup.AddEntry(plObject, pPoolTemplate->MinLimit, pPoolTemplate->MaxLimit);
                 SearchPair p(guid, pool_id);
                 mCreatureSearchMap.insert(p);
 
@@ -699,7 +711,7 @@ void PoolMgr::LoadFromDB()
                 PoolObject plObject = PoolObject(guid, chance);
                 PoolGroup<GameObject>& gogroup = mPoolGameobjectGroups[pool_id];
                 gogroup.SetPoolId(pool_id);
-                gogroup.AddEntry(plObject, pPoolTemplate->MaxLimit);
+                gogroup.AddEntry(plObject, pPoolTemplate->MinLimit, pPoolTemplate->MaxLimit);
                 SearchPair p(guid, pool_id);
                 mGameobjectSearchMap.insert(p);
 
@@ -759,7 +771,7 @@ void PoolMgr::LoadFromDB()
                 PoolObject plObject = PoolObject(child_pool_id, chance);
                 PoolGroup<Pool>& plgroup = mPoolPoolGroups[mother_pool_id];
                 plgroup.SetPoolId(mother_pool_id);
-                plgroup.AddEntry(plObject, pPoolTemplateMother->MaxLimit);
+                plgroup.AddEntry(plObject, pPoolTemplateMother->MinLimit, pPoolTemplateMother->MaxLimit);
                 SearchPair p(child_pool_id, mother_pool_id);
                 mPoolSearchMap.insert(p);
 
@@ -871,7 +883,7 @@ void PoolMgr::LoadFromDB()
                 PoolObject plObject = PoolObject(entry, 0.0f);
                 PoolGroup<Quest>& questgroup = mPoolQuestGroups[pool_id];
                 questgroup.SetPoolId(pool_id);
-                questgroup.AddEntry(plObject, pPoolTemplate->MaxLimit);
+                questgroup.AddEntry(plObject, pPoolTemplate->MinLimit, pPoolTemplate->MaxLimit);
                 SearchPair p(entry, pool_id);
                 mQuestSearchMap.insert(p);
 
@@ -1001,7 +1013,7 @@ template<>
 void PoolMgr::SpawnPool<Creature>(uint32 pool_id, uint32 db_guid)
 {
     if (!mPoolCreatureGroups[pool_id].isEmpty())
-        mPoolCreatureGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        mPoolCreatureGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MinLimit, mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
@@ -1010,7 +1022,7 @@ template<>
 void PoolMgr::SpawnPool<GameObject>(uint32 pool_id, uint32 db_guid)
 {
     if (!mPoolGameobjectGroups[pool_id].isEmpty())
-        mPoolGameobjectGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        mPoolGameobjectGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MinLimit, mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
@@ -1019,7 +1031,7 @@ template<>
 void PoolMgr::SpawnPool<Pool>(uint32 pool_id, uint32 sub_pool_id)
 {
     if (!mPoolPoolGroups[pool_id].isEmpty())
-        mPoolPoolGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
+        mPoolPoolGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MinLimit, mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
 }
 
 // Call to spawn a pool
@@ -1027,7 +1039,7 @@ template<>
 void PoolMgr::SpawnPool<Quest>(uint32 pool_id, uint32 quest_id)
 {
     if (!mPoolQuestGroups[pool_id].isEmpty())
-        mPoolQuestGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, quest_id);
+        mPoolQuestGroups[pool_id].SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MinLimit, mPoolTemplate[pool_id].MaxLimit, quest_id);
 }
 
 void PoolMgr::SpawnPool(uint32 pool_id)
@@ -1076,7 +1088,176 @@ void PoolMgr::UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id)
         SpawnPool<T>(pool_id, db_guid_or_pool_id);
 }
 
+PoolTemplateData* PoolMgr::GetPoolTemplate(uint32 pool_id)
+{
+    if (pool_id >= 1 && pool_id <= max_pool_id)
+    {
+        PoolTemplateData* pPoolTemplate = &mPoolTemplate[pool_id];
+        return pPoolTemplate;
+    }
+    return NULL;
+}
+
+uint32 PoolMgr::GetPoolActiveSpawns(uint32 pool_id)
+{
+    if (pool_id >= 1 && pool_id <= max_pool_id)
+        return mSpawnedData.GetActiveObjectCount(pool_id);
+
+    return 0;
+}
+
+// Handle creature death, including expediting corpse removal
+void PoolMgr::HandleCreatureDeath(uint32 guid)
+{
+    if (uint32 pool_id = IsPartOfAPool<Creature>(guid))
+    {
+        if (NeedExpeditedRespawn(guid))
+        {
+            if (Creature* creature = FindDeadCreature(pool_id, true))
+            {
+                // If the best we could find was a corpse, despawn it.
+                // The creature class will respawn it for us
+                if (creature->getDeathState() == CORPSE)
+                {
+                    creature->RemoveCorpse();
+                }
+
+                // If we found a despawned corpse, just respawn it now
+                if (creature->getDeathState() == DEAD)
+                {
+                    creature->Respawn();
+                }
+            }
+        }
+    }
+    
+}
+
+// Decide if we need to expedite a respawn
+bool PoolMgr::NeedExpeditedRespawn(uint32 guid)
+{
+    if (uint32 pool_id = IsPartOfAPool<Creature>(guid))
+        if (GetAliveCreatures(guid) < GetPoolTemplate(pool_id)->MinLimit)
+            return true;
+
+    return false;
+}
+
+// Return number of alive active creatured in same pool as specified creature
+uint32 PoolMgr::GetAliveCreatures(uint32 guid)
+{
+    if (uint32 pool_id = IsPartOfAPool<Creature>(guid))
+    {
+        uint32 creatureCount = 0;
+ 
+        PoolObjectList exChance = mPoolCreatureGroups[pool_id].GetExplicitlyChanced();
+        PoolObjectList eqChance = mPoolCreatureGroups[pool_id].GetEqualChanced();
+
+        if (!exChance.empty())
+        {
+            for (uint32 i = 0; i < exChance.size(); ++i)
+            {
+                if (CreatureData const* data = sObjectMgr->GetCreatureData(exChance[i].guid))
+                    if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, exChance[i].guid), (Creature*)NULL))
+                        if (creature->IsAlive())
+                        {
+                            ++creatureCount;
+                        }
+            }
+        }
+ 
+        if (!eqChance.empty())
+        {
+            for (uint32 i = 0; i < eqChance.size(); ++i)
+            {
+                if (CreatureData const* data = sObjectMgr->GetCreatureData(eqChance[i].guid))
+                    if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, eqChance[i].guid), (Creature*)NULL))
+                        if (creature->IsAlive())
+                        {
+                            ++creatureCount;
+                        }
+            }
+        }
+        return creatureCount;
+    }
+    return 0;
+}
+
+// Find first dead creature in the pool.
+// If requested and there is an unlooted dead creature, return that creature
+// Otherwise, return a looted one
+// Overall prefer a despawned corpse.
+Creature* PoolMgr::FindDeadCreature(uint32 pool_id, bool PreferLooted)
+{
+    PoolObjectList exChance = mPoolCreatureGroups[pool_id].GetExplicitlyChanced();
+    PoolObjectList eqChance = mPoolCreatureGroups[pool_id].GetEqualChanced();
+
+    // Placeholder for first found dead creature
+    Creature* firstDead;
+    Creature* firstUnlooted;
+    firstDead = NULL;
+
+    // Search exChance first
+    if (!exChance.empty())
+    {
+        for (uint32 i = 0; i < exChance.size(); ++i)
+        {
+            // If object is active
+            if (mSpawnedData.IsActiveObject<Creature>(exChance[i].guid))
+            {
+                // Get the creature data for this object
+                if (CreatureData const* data = sObjectMgr->GetCreatureData(exChance[i].guid))
+                {
+                    if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, exChance[i].guid), (Creature*)NULL))
+                    {
+                        if (!creature->IsAlive() && (creature->getDeathState() == CORPSE || creature->getDeathState() == DEAD))
+                        {
+                            if (creature->getDeathState() == DEAD)
+                                return creature;
+                            if (creature->loot.isLooted() || !PreferLooted)
+                                firstUnlooted = creature;
+                            if (!creature->loot.isLooted() && PreferLooted && firstDead == NULL)
+                                firstDead = creature;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!eqChance.empty())
+    {
+        for (uint32 i = 0; i < eqChance.size(); ++i)
+        {
+            if (mSpawnedData.IsActiveObject<Creature>(eqChance[i].guid))
+            {
+                if (CreatureData const* data = sObjectMgr->GetCreatureData(eqChance[i].guid))
+                {
+                    if (Creature* creature = ObjectAccessor::GetObjectInWorld(ObjectGuid(HIGHGUID_UNIT, data->id, eqChance[i].guid), (Creature*)NULL))
+                    {
+                        if (!creature->IsAlive() && (creature->getDeathState() == CORPSE || creature->getDeathState() == DEAD))
+                        {
+                            if (creature->getDeathState() == DEAD)
+                                return creature;
+                            if (creature->loot.isLooted() || !PreferLooted)
+                                firstUnlooted = creature;
+                            if (!creature->loot.isLooted() && PreferLooted && firstDead == NULL)
+                                firstDead = creature;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (firstUnlooted)
+        return firstUnlooted;
+    return firstDead;
+
+//    return mPoolCreatureGroups[pool_id].FindDeadCreature(&mSpawnedData, PreferLooted);
+}
+
 template void PoolMgr::UpdatePool<Pool>(uint32 pool_id, uint32 db_guid_or_pool_id);
 template void PoolMgr::UpdatePool<GameObject>(uint32 pool_id, uint32 db_guid_or_pool_id);
 template void PoolMgr::UpdatePool<Creature>(uint32 pool_id, uint32 db_guid_or_pool_id);
 template void PoolMgr::UpdatePool<Quest>(uint32 pool_id, uint32 db_guid_or_pool_id);
+

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -26,6 +26,7 @@
 
 struct PoolTemplateData
 {
+    uint32  MinLimit;
     uint32  MaxLimit;
 };
 
@@ -74,12 +75,12 @@ class PoolGroup
         void SetPoolId(uint32 pool_id) { poolId = pool_id; }
         ~PoolGroup() { };
         bool isEmpty() const { return ExplicitlyChanced.empty() && EqualChanced.empty(); }
-        void AddEntry(PoolObject& poolitem, uint32 maxentries);
+        void AddEntry(PoolObject& poolitem, uint32 minentries, uint32 maxentries);
         bool CheckPool() const;
         PoolObject* RollOne(ActivePoolData& spawns, uint32 triggerFrom);
         void DespawnObject(ActivePoolData& spawns, uint32 guid=0);
         void Despawn1Object(uint32 guid);
-        void SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom);
+        void SpawnObject(ActivePoolData& spawns, uint32 minlimit, uint32 maxlimit, uint32 triggerFrom);
 
         void Spawn1Object(PoolObject* obj);
         void ReSpawn1Object(PoolObject* obj);
@@ -91,6 +92,8 @@ class PoolGroup
             return EqualChanced.front().guid;
         }
         uint32 GetPoolId() const { return poolId; }
+        PoolObjectList GetExplicitlyChanced() const { return ExplicitlyChanced; }
+        PoolObjectList GetEqualChanced() const { return EqualChanced; }
     private:
         uint32 poolId;
         PoolObjectList ExplicitlyChanced;
@@ -103,6 +106,7 @@ typedef std::pair<PooledQuestRelation::iterator, PooledQuestRelation::iterator> 
 
 class PoolMgr
 {
+    typedef std::vector<PoolObject> PoolObjectList;
     private:
         PoolMgr();
         ~PoolMgr() { };
@@ -114,6 +118,8 @@ class PoolMgr
             return &instance;
         }
 
+        PoolTemplateData* GetPoolTemplate(uint32 pool_id);
+        uint32 GetPoolActiveSpawns(uint32 pool_id);
         void LoadFromDB();
         void LoadQuestPools();
         void SaveQuestsToDB();
@@ -122,6 +128,11 @@ class PoolMgr
 
         template<typename T>
         uint32 IsPartOfAPool(uint32 db_guid_or_pool_id) const;
+
+        Creature* FindDeadCreature(uint32 pool_id, bool PreferLooted);
+        void HandleCreatureDeath(uint32 guid);
+        uint32 GetAliveCreatures(uint32 guid);
+        bool NeedExpeditedRespawn(uint32 guid);
 
         template<typename T>
         bool IsSpawnedObject(uint32 db_guid_or_pool_id) const { return mSpawnedData.IsActiveObject<T>(db_guid_or_pool_id); }

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -28,6 +28,7 @@ EndScriptData */
 #include "Transport.h"
 #include "CreatureGroups.h"
 #include "Language.h"
+#include "PoolMgr.h"
 #include "TargetedMovementGenerator.h"                      // for HandleNpcUnFollowCommand
 #include "CreatureAI.h"
 #include "Player.h"
@@ -725,6 +726,8 @@ public:
         uint32 displayid = target->GetDisplayId();
         uint32 nativeid = target->GetNativeDisplayId();
         uint32 Entry = target->GetEntry();
+        uint32 npcPool = sPoolMgr->IsPartOfAPool<Creature>(target->GetDBTableGUIDLow());
+        PoolTemplateData *tempPoolTemp;
 
         int64 curRespawnDelay = target->GetRespawnTimeEx()-time(NULL);
         if (curRespawnDelay < 0)
@@ -733,6 +736,9 @@ public:
         std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), true);
 
         handler->PSendSysMessage(LANG_NPCINFO_CHAR,  target->GetDBTableGUIDLow(), target->GetGUIDLow(), faction, npcflags, Entry, displayid, nativeid);
+        if (npcPool)
+            handler->PSendSysMessage(LANG_NPCINFO_POOLINFO, npcPool, sPoolMgr->GetPoolTemplate(npcPool)->MinLimit, sPoolMgr->GetPoolTemplate(npcPool)->MaxLimit, sPoolMgr->GetAliveCreatures(target->GetDBTableGUIDLow()));
+
         handler->PSendSysMessage(LANG_NPCINFO_LEVEL, target->getLevel());
         handler->PSendSysMessage(LANG_NPCINFO_EQUIPMENT, target->GetCurrentEquipmentId(), target->GetOriginalEquipmentId());
         handler->PSendSysMessage(LANG_NPCINFO_HEALTH, target->GetCreateHealth(), target->GetMaxHealth(), target->GetHealth());


### PR DESCRIPTION
The aim of this branch is to update the pooling system as follows:
- Create a possibility to specify a minimum number of spawned objects
- Ensure the maximum value are actually spawned
- Ensure that the minumum number are maintained in the world

Completion: 40%
- Databases and Pool functionality updated to handle minimum value in template: 100%
- Added pool information to npc info (creature pool): 100%
- Spawn insurance of 100% max spawn if possible: 80% (this seems to work, but I have seen npc info report not all spawned. So need to check)

Creature specific:
- When creatures in pool drop below minimum, then process is as follows: (100% but needs testing)
  - looks for a dead despawned creature in the pool, if found - instant respawn
  - if none despawned, looks for a looted corpse. If found, despawns corpse
  - if no looted corpses found, then finds an unlooted corpse and despawns it
  - Creature class upon creature despawn, will check if an expedited respawn is required. If so, will respawn right away.
  
  Resource Node (maybe all game objects in pools) specific:
- When nodes in pool drop below minimum, then process to be determined to maintain minimum nodes in pool (0%)
  
  To Do:
- Currently more is exposed in PoolManager class than needs to be (this is due to extra detail being shows in npc info for debug purposes during development)
- I'm not too happy about making the ExplicitlyChanced and EqualChanced lists directly available from PoolGroup. But, it was the fastest way to achieve this.
  It doesn't seem to pose a terrible problem.

Adjusted to use minumum of available pool spots or maximum spawns for target to spawn
